### PR TITLE
fix: fix import on windows

### DIFF
--- a/sip/PyQt6Ads.sip
+++ b/sip/PyQt6Ads.sip
@@ -1,6 +1,18 @@
 %Module(name=PyQt6Ads, call_super_init=True, keyword_arguments="Optional", use_limited_api=True)
 %HideNamespace(name=ads)
 
+%If (WIN32)
+%ModuleCode
+    PyObject* pyqt6_module = PyImport_ImportModule("PyQt6");
+    if (pyqt6_module == NULL) {
+        PyErr_SetString(PyExc_ImportError, "Failed to import PyQt6");
+        return;
+    }
+    Py_DECREF(pyqt6_module);
+%End
+%End
+
+
 %Import QtCore/QtCoremod.sip
 %DefaultSupertype PyQt6.sip.simplewrapper
 

--- a/sip/PyQt6Ads.sip
+++ b/sip/PyQt6Ads.sip
@@ -1,7 +1,7 @@
 %Module(name=PyQt6Ads, call_super_init=True, keyword_arguments="Optional", use_limited_api=True)
 %HideNamespace(name=ads)
 
-%If (WIN32)
+%If defined(_WIN32)
 %ModuleCode
     PyObject* pyqt6_module = PyImport_ImportModule("PyQt6");
     if (pyqt6_module == NULL) {
@@ -9,7 +9,6 @@
         return;
     }
     Py_DECREF(pyqt6_module);
-%End
 %End
 
 

--- a/sip/PyQt6Ads.sip
+++ b/sip/PyQt6Ads.sip
@@ -3,13 +3,18 @@
 
 %ModuleCode
 #ifdef _WIN32
-// Import PyQt6 first so that os.add_dll_directory is called (for windows)
-PyObject* pyqt6_module = PyImport_ImportModule("PyQt6");
-if (pyqt6_module == NULL) {
-    PyErr_SetString(PyExc_ImportError, "Failed to import PyQt6");
-    return;
-}
-Py_DECREF(pyqt6_module);
+// Run at module initialization time
+struct PyQt6Importer {
+    PyQt6Importer() {
+        PyObject* pyqt6_module = PyImport_ImportModule("PyQt6");
+        if (!pyqt6_module) {
+            PyErr_SetString(PyExc_ImportError, "Failed to import PyQt6");
+            return;
+        }
+        Py_DECREF(pyqt6_module);
+    }
+};
+static PyQt6Importer _pyqt6_importer;  // Runs at module init
 #endif
 %End
 

--- a/sip/PyQt6Ads.sip
+++ b/sip/PyQt6Ads.sip
@@ -1,14 +1,16 @@
 %Module(name=PyQt6Ads, call_super_init=True, keyword_arguments="Optional", use_limited_api=True)
 %HideNamespace(name=ads)
 
-%If defined(_WIN32)
 %ModuleCode
-    PyObject* pyqt6_module = PyImport_ImportModule("PyQt6");
-    if (pyqt6_module == NULL) {
-        PyErr_SetString(PyExc_ImportError, "Failed to import PyQt6");
-        return;
-    }
-    Py_DECREF(pyqt6_module);
+#ifdef _WIN32
+// Import PyQt6 first so that os.add_dll_directory is called (for windows)
+PyObject* pyqt6_module = PyImport_ImportModule("PyQt6");
+if (pyqt6_module == NULL) {
+    PyErr_SetString(PyExc_ImportError, "Failed to import PyQt6");
+    return;
+}
+Py_DECREF(pyqt6_module);
+#endif
 %End
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import PyQt6Ads  # noqa
 from PyQt6.QtWidgets import QApplication
 
 HERE = Path(__file__)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2,8 +2,8 @@ import runpy
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 import PyQt6Ads  # noqa
+import pytest
 from PyQt6.QtWidgets import QApplication
 
 HERE = Path(__file__)


### PR DESCRIPTION
the package isn't currently working on windows unless you *first* import PyQt6, which calls `os.add_dll_directory`.  This PR just imports PyQt6 first manually, (so that it can add the dll directory)