### PR TITLE
use updated sip files from  from char101

### DIFF
--- a/sip/AutoHideDockContainer.sip
+++ b/sip/AutoHideDockContainer.sip
@@ -5,10 +5,9 @@ namespace ads
 
 class CAutoHideDockContainer : QFrame
 {
-
-    %TypeHeaderCode
-    #include <AutoHideDockContainer.h>
-    %End
+%TypeHeaderCode
+#include <AutoHideDockContainer.h>
+%End
 
 protected:
 	virtual bool eventFilter(QObject* watched, QEvent* event);
@@ -19,27 +18,26 @@ protected:
 	void saveState(QXmlStreamWriter& Stream);
 
 public:
-	CAutoHideDockContainer(ads::CDockWidget* DockWidget /Transfer/, ads::SideBarLocation area,
-		ads::CDockContainerWidget* parent /TransferThis/);
+	CAutoHideDockContainer(CDockWidget* DockWidget /Transfer/, ads::SideBarLocation area, CDockContainerWidget* parent /TransferThis/);
 	virtual ~CAutoHideDockContainer();
-	ads::CAutoHideSideBar* autoHideSideBar() const;
-	ads::CAutoHideTab* autoHideTab() const;
-	ads::CDockWidget* dockWidget() const;
-    int tabIndex() const;
-	void addDockWidget(ads::CDockWidget* DockWidget /Transfer/);
-	ads::SideBarLocation sideBarLocation() const;
-	void setSideBarLocation(ads::SideBarLocation SideBarLocation);
-	ads::CDockAreaWidget* dockAreaWidget() const;
-	ads::CDockContainerWidget* dockContainer() const;
-    void moveContentsToParent();
+	CAutoHideSideBar* autoHideSideBar() const;
+	CAutoHideTab* autoHideTab() const;
+	CDockWidget* dockWidget() const;
+	int tabIndex() const;
+	void addDockWidget(CDockWidget* DockWidget /Transfer/);
+	SideBarLocation sideBarLocation() const;
+	void setSideBarLocation(SideBarLocation SideBarLocation);
+	CDockAreaWidget* dockAreaWidget() const;
+	CDockContainerWidget* dockContainer() const;
+	void moveContentsToParent();
 	void cleanupAndDelete();
 	void toggleView(bool Enable);
 	void collapseView(bool Enable);
 	void toggleCollapseState();
 	void setSize(int Size);
-    void resetToInitialDockWidgetSize();
-    Qt::Orientation orientation() const;
-    void moveToNewSideBarLocation(ads::SideBarLocation);
+	void resetToInitialDockWidgetSize();
+	Qt::Orientation orientation() const;
+	void moveToNewSideBarLocation(SideBarLocation);
 };
 
 };

--- a/sip/AutoHideSideBar.sip
+++ b/sip/AutoHideSideBar.sip
@@ -3,35 +3,34 @@
 namespace ads
 {
 
-
 class CAutoHideSideBar : QScrollArea
 {
 
-    %TypeHeaderCode
-    #include <AutoHideSideBar.h>
-    %End
+%TypeHeaderCode
+#include <AutoHideSideBar.h>
+%End
 
 protected:
 	virtual bool eventFilter(QObject *watched, QEvent *event);
 	void saveState(QXmlStreamWriter& Stream) const;
-	void insertTab(int Index, ads::CAutoHideTab* SideTab /Transfer/);
+	void insertTab(int Index, CAutoHideTab* SideTab /Transfer/);
 
 public:
-    CAutoHideSideBar(ads::CDockContainerWidget* parent /TransferThis/, SideBarLocation area);
+	CAutoHideSideBar(CDockContainerWidget* parent /TransferThis/, SideBarLocation area);
 	virtual ~CAutoHideSideBar();
-	void removeTab(ads::CAutoHideTab* SideTab) /TransferBack/;
-	ads::CAutoHideDockContainer* insertDockWidget(int Index, ads::CDockWidget* DockWidget /Transfer/);
-	void removeAutoHideWidget(ads::CAutoHideDockContainer* AutoHideWidget) /TransferBack/;
-	void addAutoHideWidget(ads::CAutoHideDockContainer* AutoHideWidget, int Index);
+	void removeTab(CAutoHideTab* SideTab) /TransferBack/;
+	CAutoHideDockContainer* insertDockWidget(int Index, CDockWidget* DockWidget /Transfer/);
+	void removeAutoHideWidget(CAutoHideDockContainer* AutoHideWidget) /TransferBack/;
+	void addAutoHideWidget(CAutoHideDockContainer* AutoHideWidget, int Index);
 	Qt::Orientation orientation() const;
-	ads::CAutoHideTab* tab(int index) const;
-    int tabAt(const QPoint& Pos) const;
-    int tabInsertIndexAt(const QPoint& Pos) const;
-    int indexOfTab(const CAutoHideTab& Tab) const;
+	CAutoHideTab* tab(int index) const;
+	int tabAt(const QPoint& Pos) const;
+	int tabInsertIndexAt(const QPoint& Pos) const;
+	int indexOfTab(const CAutoHideTab& Tab) const;
 	int count() const;
-    int visibleTabCount() const;
-    bool hasVisibleTabs() const;
-	ads::SideBarLocation sideBarLocation() const;
+	int visibleTabCount() const;
+	bool hasVisibleTabs() const;
+	SideBarLocation sideBarLocation() const;
 	virtual QSize minimumSizeHint() const;
 	virtual QSize sizeHint() const;
 	int spacing() const;

--- a/sip/AutoHideTab.sip
+++ b/sip/AutoHideTab.sip
@@ -5,36 +5,40 @@ namespace ads
 
 class CAutoHideTab : CPushButton
 {
-    
-    %TypeHeaderCode
-    #include <AutoHideTab.h>
-    %End
+
+%TypeHeaderCode
+#include <AutoHideTab.h>
+%End
 
 protected:
-	void setSideBar(ads::CAutoHideSideBar *SideTabBar);
-	void removeFromSideBar();
-    virtual bool event(QEvent* event);
-    virtual void contextMenuEvent(QContextMenuEvent* ev);
-	virtual void mousePressEvent(QMouseEvent* ev);
-	virtual void mouseReleaseEvent(QMouseEvent* ev);
-	virtual void mouseMoveEvent(QMouseEvent* ev);
+  void setSideBar(CAutoHideSideBar *SideTabBar /Transfer/);
+  void removeFromSideBar();
+  virtual bool event(QEvent* event);
+  virtual void contextMenuEvent(QContextMenuEvent* ev);
+  virtual void mousePressEvent(QMouseEvent* ev);
+  virtual void mouseReleaseEvent(QMouseEvent* ev);
+  virtual void mouseMoveEvent(QMouseEvent* ev);
+  virtual void dragEnterEvent(QDragEnterEvent* ev);
+  virtual void dragLeaveEvent(QDragLeaveEvent* ev);
 
 public:
-	CAutoHideTab(QWidget* parent /TransferThis/ = 0);
-	virtual ~CAutoHideTab();
-	void updateStyle();
-	ads::SideBarLocation sideBarLocation() const;
-	void setOrientation(Qt::Orientation Orientation);
-	Qt::Orientation orientation() const;
-	bool isActiveTab() const;
-	ads::CDockWidget* dockWidget() const;
-	void setDockWidget(ads::CDockWidget* DockWidget);
-	bool iconOnly() const;
-	ads::CAutoHideSideBar* sideBar() const;
-    int tabIndex() const;
-    void setDockWidgetFloating();
-    void unpinDockWidget();
-    void requestCloseDockWidget();
+  CAutoHideTab(QWidget* parent /TransferThis/ = nullptr);
+  virtual ~CAutoHideTab();
+  void updateStyle();
+  SideBarLocation sideBarLocation() const;
+  void setOrientation(Qt::Orientation Orientation);
+  Qt::Orientation orientation() const;
+  bool isActiveTab() const;
+  CDockWidget* dockWidget() const;
+  void setDockWidget(CDockWidget* DockWidget);
+  bool iconOnly() const;
+  CAutoHideSideBar* sideBar() const;
+  int tabIndex() const;
+
+public slots:
+  void setDockWidgetFloating();
+  void unpinDockWidget();
+  void requestCloseDockWidget();
 };
 
 };

--- a/sip/DockAreaTabBar.sip
+++ b/sip/DockAreaTabBar.sip
@@ -5,44 +5,45 @@ namespace ads
 
 class CDockAreaTabBar : QScrollArea
 {
-    %TypeHeaderCode
-    #include <DockAreaTabBar.h>
-    %End
+%TypeHeaderCode
+#include <DockAreaTabBar.h>
+%End
     
 protected:
-	virtual void wheelEvent(QWheelEvent* Event);
+  virtual void wheelEvent(QWheelEvent* Event);
 
 public:
-	CDockAreaTabBar(ads::CDockAreaWidget* parent /TransferThis/);
-	virtual ~CDockAreaTabBar();
-	void insertTab(int Index, ads::CDockWidgetTab* Tab /Transfer/);
-	void removeTab(ads::CDockWidgetTab* Tab) /TransferBack/;
-	int count() const;
-	int currentIndex() const;
-	ads::CDockWidgetTab* currentTab() const;
-	ads::CDockWidgetTab* tab(int Index) const;
-    int tabAt(const QPoint& Pos) const;
-    int tabInsertIndexAt(const QPoint& Pos) const;
-	virtual bool eventFilter(QObject *watched, QEvent *event);
-	bool isTabOpen(int Index) const;
-	virtual QSize minimumSizeHint() const;
-	virtual QSize sizeHint() const;
- 	void elidedChanged(bool elided);
+  CDockAreaTabBar(CDockAreaWidget* parent /TransferThis/);
+  virtual ~CDockAreaTabBar();
+  void insertTab(int Index, CDockWidgetTab* Tab /Transfer/);
+  void removeTab(CDockWidgetTab* Tab) /TransferBack/;
+  int count() const;
+  int currentIndex() const;
+  CDockWidgetTab* currentTab() const;
+  CDockWidgetTab* tab(int Index) const;
+  int tabAt(const QPoint& Pos) const;
+  int tabInsertIndexAt(const QPoint& Pos) const;
+  virtual bool eventFilter(QObject *watched, QEvent *event);
+  bool isTabOpen(int Index) const;
+  virtual QSize minimumSizeHint() const;
+  virtual QSize sizeHint() const;
+  bool areTabsOverflowing() const;
 
 public slots:
-	void setCurrentIndex(int Index);
-	void closeTab(int Index);
+  void setCurrentIndex(int Index);
+  void closeTab(int Index);
 
 signals:
-	void currentChanging(int Index);
-	void currentChanged(int Index);
-	void tabBarClicked(int index);
-	void tabCloseRequested(int index);
-	void tabClosed(int index);
-	void tabOpened(int index);
-	void tabMoved(int from, int to);
-	void removingTab(int index);
-	void tabInserted(int index);
+  void currentChanging(int Index);
+  void currentChanged(int Index);
+  void tabBarClicked(int index);
+  void tabCloseRequested(int index);
+  void tabClosed(int index);
+  void tabOpened(int index);
+  void tabMoved(int from, int to);
+  void removingTab(int index);
+  void tabInserted(int index);
+  void elidedChanged(bool elided);
 };
 
 };

--- a/sip/DockAreaTitleBar.sip
+++ b/sip/DockAreaTitleBar.sip
@@ -5,59 +5,58 @@ namespace ads
 
 class CTitleBarButton : QToolButton
 {
-    %TypeHeaderCode
-    #include <DockAreaTitleBar.h>
-    %End
-    
-public:
-	CTitleBarButton(bool ShowInTitleBar, bool HideWhenDisabled, TitleBarButton ButtonId,
-		QWidget* /TransferThis/ = Q_NULLPTR );
-	virtual void setVisible(bool);
-	void setShowInTitleBar(bool);
+%TypeHeaderCode
+#include <DockAreaTitleBar.h>
+%End
 
-    TitleBarButton buttonId() const;
-	ads::CDockAreaTitleBar* titleBar() const;
-    bool isInAutoHideArea() const;
+public:
+  CTitleBarButton(bool ShowInTitleBar, bool HideWhenDisabled, TitleBarButton ButtonId, QWidget* parent /TransferThis/ = nullptr);
+  virtual void setVisible(bool);
+  void setShowInTitleBar(bool);
+  TitleBarButton buttonId() const;
+  CDockAreaTitleBar* titleBar() const;
+  bool isInAutoHideArea() const;
 
 protected:
-	bool event(QEvent *ev);
+  bool event(QEvent *ev);
 };
 
 class CDockAreaTitleBar : QFrame
 {
-    %TypeHeaderCode
-    #include <DockAreaTitleBar.h>
-    %End
+%TypeHeaderCode
+#include <DockAreaTitleBar.h>
+%End
 
 protected:
-	virtual void mousePressEvent(QMouseEvent* ev);
-	virtual void mouseReleaseEvent(QMouseEvent* ev);
-	virtual void mouseMoveEvent(QMouseEvent* ev);
-	virtual void mouseDoubleClickEvent(QMouseEvent *event);
-	virtual void contextMenuEvent(QContextMenuEvent *event);
+  virtual void mousePressEvent(QMouseEvent* ev);
+  virtual void mouseReleaseEvent(QMouseEvent* ev);
+  virtual void mouseMoveEvent(QMouseEvent* ev);
+  virtual void mouseDoubleClickEvent(QMouseEvent *event);
+  virtual void contextMenuEvent(QContextMenuEvent *event);
+  virtual void resizeEvent(QResizeEvent *event);
 
 public slots:
-	void markTabsMenuOutdated();
-
+  void markTabsMenuOutdated();
 
 public:
-	CDockAreaTitleBar(ads::CDockAreaWidget* parent /TransferThis/);
-	virtual ~CDockAreaTitleBar();
-	ads::CDockAreaTabBar* tabBar() const;
-	ads::CTitleBarButton* button(ads::TitleBarButton which) const;
-    ads::CElidingLabel* autoHideTitleLabel() const;
-    ads::CDockAreaWidget* dockAreaWidget() const;
- 	void updateDockWidgetActionsButtons();
-	virtual void setVisible(bool Visible);
-	void insertWidget(int index, QWidget *widget /Transfer/ );
-	int indexOf(QWidget *widget) const;
-    QString titleBarButtonToolTip(ads::TitleBarButton Button) const;
-    void setAreaFloating();
-    void showAutoHideControls(bool Show);
-    bool isAutoHide() const;
+  CDockAreaTitleBar(CDockAreaWidget* parent /TransferThis/);
+  virtual ~CDockAreaTitleBar();
+  CDockAreaTabBar* tabBar() const;
+  CTitleBarButton* button(TitleBarButton which) const;
+  CElidingLabel* autoHideTitleLabel() const;
+  CDockAreaWidget* dockAreaWidget() const;
+  void updateDockWidgetActionsButtons();
+  virtual void setVisible(bool Visible);
+  void insertWidget(int index, QWidget *widget /Transfer/);
+  int indexOf(QWidget *widget) const;
+  QString titleBarButtonToolTip(TitleBarButton Button) const;
+  void setAreaFloating();
+  void showAutoHideControls(bool Show);
+  bool isAutoHide() const;
+  virtual QMenu *buildContextMenu(QMenu *menu /Transfer/ = nullptr);
 
 signals:
-	void tabBarClicked(int index);
+  void tabBarClicked(int index);
 };
 
 };

--- a/sip/DockAreaTitleBar_p.sip
+++ b/sip/DockAreaTitleBar_p.sip
@@ -5,12 +5,12 @@ namespace ads
 
 class CSpacerWidget : QWidget
 {
-    %TypeHeaderCode
-    #include <DockAreaTitleBar_p.h>
-    %End
+%TypeHeaderCode
+#include <DockAreaTitleBar_p.h>
+%End
 
 public:
-	CSpacerWidget(QWidget* Parent /TransferThis/ = 0 );
+	CSpacerWidget(QWidget* Parent /TransferThis/ = nullptr);
 	virtual QSize sizeHint() const;
 	virtual QSize minimumSizeHint() const;
 };

--- a/sip/DockAreaWidget.sip
+++ b/sip/DockAreaWidget.sip
@@ -5,87 +5,85 @@ namespace ads
 
 class CDockAreaWidget : QFrame
 {
+%TypeHeaderCode
+#include <DockAreaWidget.h>
+%End
 
-    %TypeHeaderCode
-    #include <DockAreaWidget.h>
-    %End
-    
 protected:
-	void insertDockWidget(int index, ads::CDockWidget* DockWidget /Transfer/, bool Activate = true);
-	void addDockWidget(ads::CDockWidget* DockWidget /Transfer/);
-	void removeDockWidget(ads::CDockWidget* DockWidget) /TransferBack/;
-	void toggleDockWidgetView(ads::CDockWidget* DockWidget, bool Open);
-	CDockWidget* nextOpenDockWidget(ads::CDockWidget* DockWidget) const;
-	int index(ads::CDockWidget* DockWidget);
-	void hideAreaWithNoVisibleContent();
-	void updateTitleBarVisibility();
-	void internalSetCurrentDockWidget(ads::CDockWidget* DockWidget /Transfer/);
-	void markTitleBarMenuOutdated();
-    void updateTitleBarButtonVisibility(bool IsTopLevel) const;
+  void insertDockWidget(int index, CDockWidget* DockWidget /Transfer/, bool Activate = true);
+  void addDockWidget(CDockWidget* DockWidget /Transfer/);
+  void removeDockWidget(CDockWidget* DockWidget) /TransferBack/;
+  void toggleDockWidgetView(CDockWidget* DockWidget, bool Open);
+  CDockWidget* nextOpenDockWidget(CDockWidget* DockWidget) const;
+  int index(CDockWidget* DockWidget);
+  void hideAreaWithNoVisibleContent();
+  void updateTitleBarVisibility();
+  void internalSetCurrentDockWidget(CDockWidget* DockWidget /Transfer/);
+  void markTitleBarMenuOutdated();
+  void updateTitleBarButtonVisibility(bool IsTopLevel) const;
 
 protected slots:
-	void toggleView(bool Open);
-    
-public:
-    enum eDockAreaFlag
-	{
-		HideSingleWidgetTitleBar,
-		DefaultFlags
-	};
-    typedef QFlags<ads::CDockAreaWidget::eDockAreaFlag> DockAreaFlags;
-    
-	CDockAreaWidget(ads::CDockManager* DockManager /TransferThis/, ads::CDockContainerWidget* parent /TransferThis/);
-	virtual ~CDockAreaWidget();
-	ads::CDockManager* dockManager() const;
-	ads::CDockContainerWidget* dockContainer() const;
-    ads::CAutoHideDockContainer* autoHideDockContainer() const;
-    ads::CDockSplitter* parentSplitter() const;
-    bool isAutoHide() const;
-    void setAutoHideDockContainer(CAutoHideDockContainer*);
-	virtual QSize minimumSizeHint() const;
-	QRect titleBarGeometry() const;
-	QRect contentAreaGeometry() const;
-	int dockWidgetsCount() const;
-	QList<ads::CDockWidget*> dockWidgets() const;
-	int openDockWidgetsCount() const;
-	QList<ads::CDockWidget*> openedDockWidgets() const;
-	ads::CDockWidget* dockWidget(int Index) const;
-	int currentIndex() const;
-	int indexOfFirstOpenDockWidget() const;
-	ads::CDockWidget* currentDockWidget() const;
-	void setCurrentDockWidget(ads::CDockWidget* DockWidget);
-	void saveState(QXmlStreamWriter& Stream) const;
-    static bool restoreState(ads::CDockingStateReader& Stream, ads::CDockAreaWidget*& CreatedWidget,
-		bool Testing, ads::CDockContainerWidget* ParentContainer);
- 	ads::CDockWidget::DockWidgetFeatures features(ads::eBitwiseOperator Mode = ads::BitwiseAnd) const;
-	QAbstractButton* titleBarButton(ads::TitleBarButton which) const;
-	virtual void setVisible(bool Visible);
+  void toggleView(bool Open);
 
-	void setAllowedAreas(DockWidgetAreas areas);
-	DockWidgetAreas allowedAreas() const;
-	CDockAreaTitleBar* titleBar() const;
-    
-    DockAreaFlags dockAreaFlags() const;
-    void setDockAreaFlags(DockAreaFlags Flags);
-    void setDockAreaFlag(eDockAreaFlag Flag, bool On);
-    
-    bool isCentralWidgetArea() const;
-    bool containsCentralWidget() const;
-    bool isTopLevelArea() const;
+public:
+  enum eDockAreaFlag
+  {
+    HideSingleWidgetTitleBar,
+    DefaultFlags
+  };
+  typedef QFlags<ads::CDockAreaWidget::eDockAreaFlag> DockAreaFlags;
+
+  CDockAreaWidget(CDockManager* DockManager /TransferThis/, CDockContainerWidget* parent /TransferThis/);
+  virtual ~CDockAreaWidget();
+  CDockManager* dockManager() const;
+  CDockContainerWidget* dockContainer() const;
+  CAutoHideDockContainer* autoHideDockContainer() const;
+  CDockSplitter* parentSplitter() const;
+  bool isAutoHide() const;
+  void setAutoHideDockContainer(CAutoHideDockContainer*);
+  virtual QSize minimumSizeHint() const;
+  QRect titleBarGeometry() const;
+  QRect contentAreaGeometry() const;
+  int dockWidgetsCount() const;
+  QList<ads::CDockWidget*> dockWidgets() const;
+  int openDockWidgetsCount() const;
+  QList<ads::CDockWidget*> openedDockWidgets() const;
+  CDockWidget* dockWidget(int Index) const;
+  int currentIndex() const;
+  int indexOfFirstOpenDockWidget() const;
+  CDockWidget* currentDockWidget() const;
+  void setCurrentDockWidget(CDockWidget* DockWidget);
+  void saveState(QXmlStreamWriter& Stream) const;
+  static bool restoreState(CDockingStateReader& Stream, CDockAreaWidget*& CreatedWidget, bool Testing, CDockContainerWidget* ParentContainer);
+  CDockWidget::DockWidgetFeatures features(eBitwiseOperator Mode = ads::BitwiseAnd) const;
+  QAbstractButton* titleBarButton(TitleBarButton which) const;
+  virtual void setVisible(bool Visible);
+
+  void setAllowedAreas(DockWidgetAreas areas);
+  DockWidgetAreas allowedAreas() const;
+  CDockAreaTitleBar* titleBar() const;
+
+  DockAreaFlags dockAreaFlags() const;
+  void setDockAreaFlags(DockAreaFlags Flags);
+  void setDockAreaFlag(eDockAreaFlag Flag, bool On);
+
+  bool isCentralWidgetArea() const;
+  bool containsCentralWidget() const;
+  bool isTopLevelArea() const;
 
 public slots:
-	void setCurrentIndex(int index);
-	void closeArea();
-    void setAutoHide(bool Enable, SideBarLocation Location = ads::SideBarNone, int TabIndex = -1);
-    void toggleAutoHide(SideBarLocation Location = ads::SideBarNone);
-	void closeOtherAreas();
-    void setFloating();
+  void setCurrentIndex(int index);
+  void closeArea();
+  void setAutoHide(bool Enable, SideBarLocation Location = ads::SideBarNone, int TabIndex = -1);
+  void toggleAutoHide(SideBarLocation Location = ads::SideBarNone);
+  void closeOtherAreas();
+  void setFloating();
 
 signals:
-	void tabBarClicked(int index);
-    void currentChanging(int index);
-	void currentChanged(int index);
-	void viewToggled(bool Open);
+  void tabBarClicked(int index);
+  void currentChanging(int index);
+  void currentChanged(int index);
+  void viewToggled(bool Open);
 };
 
 };

--- a/sip/DockComponentsFactory.sip
+++ b/sip/DockComponentsFactory.sip
@@ -15,17 +15,11 @@ public:
   virtual CDockAreaTitleBar* createDockAreaTitleBar(CDockAreaWidget* DockArea /Transfer/) const;
   static const CDockComponentsFactory* factory();
 %MethodCode
-    QSharedPointer<ads::CDockComponentsFactory> *grab;
-
-    Py_BEGIN_ALLOW_THREADS
-    // This will leak but there seems to be no way to detach the object.
-    grab = new QSharedPointer<ads::CDockComponentsFactory>(ads::CDockComponentsFactory::factory());
-    Py_END_ALLOW_THREADS
-
-    sipRes = grab->data();
+        sipRes = ::ads::CDockComponentsFactory::factory().data();
 %End
   static void setFactory(CDockComponentsFactory* Factory /KeepReference/);
   static void resetDefaultFactory();
+    
 };
 
 };

--- a/sip/DockComponentsFactory.sip
+++ b/sip/DockComponentsFactory.sip
@@ -1,27 +1,31 @@
 namespace ads
 {
-    
+
 class CDockComponentsFactory
 {
-
-    %TypeHeaderCode
-    #include <DockComponentsFactory.h>
-    %End
+%TypeHeaderCode
+#include <DockComponentsFactory.h>
+%End
 
 public:
-	virtual ~CDockComponentsFactory();
-	virtual CDockWidgetTab* createDockWidgetTab(CDockWidget* DockWidget /Transfer/ ) const;
-    virtual CAutoHideTab* createDockWidgetSideTab(CDockWidget* DockWidget /Transfer/) const;
-	virtual CDockAreaTabBar* createDockAreaTabBar(CDockAreaWidget* DockArea /Transfer/ ) const;
-	virtual CDockAreaTitleBar* createDockAreaTitleBar(CDockAreaWidget* DockArea /Transfer/ ) const;
+  virtual ~CDockComponentsFactory();
+  virtual CDockWidgetTab* createDockWidgetTab(CDockWidget* DockWidget /Transfer/) const;
+  virtual CAutoHideTab* createDockWidgetSideTab(CDockWidget* DockWidget /Transfer/) const;
+  virtual CDockAreaTabBar* createDockAreaTabBar(CDockAreaWidget* DockArea /Transfer/) const;
+  virtual CDockAreaTitleBar* createDockAreaTitleBar(CDockAreaWidget* DockArea /Transfer/) const;
+  static const CDockComponentsFactory* factory();
+%MethodCode
+    QSharedPointer<ads::CDockComponentsFactory> *grab;
 
-    static CDockComponentsFactory* factory();
-    %MethodCode
-        sipRes = ::ads::CDockComponentsFactory::factory().data();
-    %End
-	static void setFactory(CDockComponentsFactory* Factory /KeepReference/);
-	static void resetDefaultFactory();
-    
+    Py_BEGIN_ALLOW_THREADS
+    // This will leak but there seems to be no way to detach the object.
+    grab = new QSharedPointer<ads::CDockComponentsFactory>(ads::CDockComponentsFactory::factory());
+    Py_END_ALLOW_THREADS
+
+    sipRes = grab->data();
+%End
+  static void setFactory(CDockComponentsFactory* Factory /KeepReference/);
+  static void resetDefaultFactory();
 };
 
 };

--- a/sip/DockComponentsFactory.sip
+++ b/sip/DockComponentsFactory.sip
@@ -15,7 +15,7 @@ public:
   virtual CDockAreaTitleBar* createDockAreaTitleBar(CDockAreaWidget* DockArea /Transfer/) const;
   static const CDockComponentsFactory* factory();
 %MethodCode
-        sipRes = ::ads::CDockComponentsFactory::factory().data();
+    sipRes = ::ads::CDockComponentsFactory::factory().data();
 %End
   static void setFactory(CDockComponentsFactory* Factory /KeepReference/);
   static void resetDefaultFactory();

--- a/sip/DockContainerWidget.sip
+++ b/sip/DockContainerWidget.sip
@@ -1,5 +1,31 @@
 %Import QtWidgets/QtWidgetsmod.sip
 
+%MappedType QList<QPointer<ads::CDockAreaWidget>> /TypeHint="List[CDockAreaWidget*]", TypeHintValue="[]"/
+{
+%TypeHeaderCode
+#include <qpointer.h>
+#include <DockAreaWidget.h>
+%End
+
+%ConvertFromTypeCode
+	PyObject *l = PyList_New(sipCpp->size());;
+	if (l == NULL)
+		return NULL;
+	
+	for (int i = 0; i < sipCpp->size(); ++i) {
+		ads::CDockAreaWidget *t = sipCpp->at(i).data();
+		PyObject *tobj = sipConvertFromType(t, sipType_ads_CDockAreaWidget, sipTransferObj);
+		if (tobj == NULL) {
+			Py_DECREF(l);
+			return NULL;
+		}
+		PyList_SetItem(l, i, tobj);
+	}
+	
+	return l;
+%End
+};
+
 namespace ads
 {
 
@@ -12,63 +38,62 @@ namespace ads
  */
 class CDockContainerWidget : QFrame
 {
-    %TypeHeaderCode
-    #include <DockContainerWidget.h>
-    %End
+	%TypeHeaderCode
+	#include <DockContainerWidget.h>
+	%End
 
 protected:
 	virtual bool event(QEvent *e);
-	ads::CDockSplitter* rootSplitter() const;
-    ads::CAutoHideDockContainer* createAndSetupAutoHideContainer(ads::SideBarLocation area, ads::CDockWidget* DockWidget /Transfer/, int TabIndex = -1);
+	CDockSplitter* rootSplitter() const;
+	CAutoHideDockContainer* createAndSetupAutoHideContainer(SideBarLocation area, CDockWidget* DockWidget /Transfer/, int TabIndex = -1);
 	void createRootSplitter();
-	void dropFloatingWidget(ads::CFloatingDockContainer* FloatingWidget, const QPoint& TargetPos);
-    void dropWidget(QWidget* Widget, DockWidgetArea DropArea, CDockAreaWidget* TargetAreaWidget, int TabIndex = -1);
-	void addDockArea(ads::CDockAreaWidget* DockAreaWidget /Transfer/, ads::DockWidgetArea area = ads::CenterDockWidgetArea);
-	void removeDockArea(ads::CDockAreaWidget* area /TransferBack/);
-    /*QList<QPointer<ads::CDockAreaWidget>> removeAllDockAreas();*/
+	void dropFloatingWidget(CFloatingDockContainer* FloatingWidget, const QPoint& TargetPos);
+	void dropWidget(QWidget* Widget, DockWidgetArea DropArea, CDockAreaWidget* TargetAreaWidget, int TabIndex = -1);
+	void addDockArea(CDockAreaWidget* DockAreaWidget /Transfer/, DockWidgetArea area = ads::CenterDockWidgetArea);
+	void removeDockArea(CDockAreaWidget* area /TransferBack/);
+	QList<QPointer<ads::CDockAreaWidget>> removeAllDockAreas();
 	void saveState(QXmlStreamWriter& Stream) const;
 	bool restoreState(CDockingStateReader& Stream, bool Testing);
-	ads::CDockAreaWidget* lastAddedDockAreaWidget(ads::DockWidgetArea area) const;
-	ads::CDockWidget* topLevelDockWidget() const;
-	ads::CDockAreaWidget* topLevelDockArea() const;
-    QList<ads::CDockWidget*> dockWidgets() const;
-    void updateSplitterHandles(QSplitter* splitter);
-    void registerAutoHideWidget(ads::CAutoHideDockContainer* AutoHideWidget /Transfer/);
-    void removeAutoHideWidget(ads::CAutoHideDockContainer* AutoHideWidget /TransferBack/);
-    void handleAutoHideWidgetEvent(QEvent* e, QWidget* w);
-    
+	CDockAreaWidget* lastAddedDockAreaWidget(DockWidgetArea area) const;
+	CDockWidget* topLevelDockWidget() const;
+	CDockAreaWidget* topLevelDockArea() const;
+	QList<ads::CDockWidget*> dockWidgets() const;
+	void updateSplitterHandles(QSplitter* splitter);
+	void registerAutoHideWidget(CAutoHideDockContainer* AutoHideWidget /Transfer/);
+	void removeAutoHideWidget(CAutoHideDockContainer* AutoHideWidget /TransferBack/);
+	void handleAutoHideWidgetEvent(QEvent* e, QWidget* w);
+
 public:
-	CDockContainerWidget(ads::CDockManager* DockManager /TransferThis/, QWidget* parent /TransferThis/ = 0);
+	CDockContainerWidget(CDockManager* DockManager /TransferThis/, QWidget* parent /TransferThis/ = 0);
 	virtual ~CDockContainerWidget();
-	ads::CDockAreaWidget* addDockWidget(ads::DockWidgetArea area, ads::CDockWidget* Dockwidget /Transfer/,
-    ads::CDockAreaWidget* DockAreaWidget /Transfer/ = 0,
-		int Index = -1);
-	void removeDockWidget(ads::CDockWidget* Dockwidget) /TransferBack/;
+	CDockAreaWidget* addDockWidget(DockWidgetArea area, CDockWidget* Dockwidget /Transfer/,
+	CDockAreaWidget* DockAreaWidget /Transfer/ = 0, int Index = -1);
+	void removeDockWidget(CDockWidget* Dockwidget) /TransferBack/;
 	virtual unsigned int zOrderIndex() const;
-	bool isInFrontOf(ads::CDockContainerWidget* Other) const;
-	ads::CDockAreaWidget* dockAreaAt(const QPoint& GlobalPos) const;
-	ads::CDockAreaWidget* dockArea(int Index) const;
+	bool isInFrontOf(CDockContainerWidget* Other) const;
+	CDockAreaWidget* dockAreaAt(const QPoint& GlobalPos) const;
+	CDockAreaWidget* dockArea(int Index) const;
 	QList<ads::CDockAreaWidget*> openedDockAreas() const;
-    QList<ads::CDockWidget*> openedDockWidgets() const;
+	QList<ads::CDockWidget*> openedDockWidgets() const;
 	bool hasTopLevelDockWidget() const;
 	int dockAreaCount() const;
 	int visibleDockAreaCount() const;
 	bool isFloating() const;
 	void dumpLayout();
-	ads::CDockWidget::DockWidgetFeatures features() const;
-	ads::CFloatingDockContainer* floatingWidget() const;
-	void closeOtherAreas(ads::CDockAreaWidget* KeepOpenArea);
-    ads::CAutoHideSideBar* autoHideSideBar(SideBarLocation area) const;
+	CDockWidget::DockWidgetFeatures features() const;
+	CFloatingDockContainer* floatingWidget() const;
+	void closeOtherAreas(CDockAreaWidget* KeepOpenArea);
+	CAutoHideSideBar* autoHideSideBar(SideBarLocation area) const;
 	QList<ads::CAutoHideDockContainer*> autoHideWidgets() const;
 	QRect contentRect() const;
 	QRect contentRectGlobal() const;
-	ads::CDockManager* dockManager() const;
+	CDockManager* dockManager() const;
 
 signals:
 	void dockAreasAdded();
-    void autoHideWidgetCreated(ads::CAutoHideDockContainer* AutoHideWidget);
+	void autoHideWidgetCreated(CAutoHideDockContainer* AutoHideWidget);
 	void dockAreasRemoved();
-	void dockAreaViewToggled(ads::CDockAreaWidget* DockArea, bool Open);
+	void dockAreaViewToggled(CDockAreaWidget* DockArea, bool Open);
 };
 
 };

--- a/sip/DockFocusController.sip
+++ b/sip/DockFocusController.sip
@@ -3,29 +3,25 @@
 namespace ads
 {
 
-/**
- * Manages focus styling of dock widgets and handling of focus changes
- */
 class CDockFocusController : QObject
 {
-    %TypeHeaderCode
-    #include <DockFocusController.h>
-    %End
+%TypeHeaderCode
+#include <DockFocusController.h>
+%End
     
 public:
-	CDockFocusController(ads::CDockManager* DockManager);
-	virtual ~CDockFocusController();
+  CDockFocusController(CDockManager* DockManager);
+  virtual ~CDockFocusController();
 
-	void notifyWidgetOrAreaRelocation(QWidget* RelocatedWidget);
-	void notifyFloatingWidgetDrop(ads::CFloatingDockContainer* FloatingWidget);
-    ads::CDockWidget* focusedDockWidget() const;
-    void setDockWidgetTabFocused(ads::CDockWidgetTab* Tab);
-    void clearDockWidgetFocus(ads::CDockWidget* dockWidget);
-    void setDockWidgetTabPressed(bool Value);
+  void notifyWidgetOrAreaRelocation(QWidget* RelocatedWidget);
+  void notifyFloatingWidgetDrop(CFloatingDockContainer* FloatingWidget);
+  CDockWidget* focusedDockWidget() const;
+  void setDockWidgetTabFocused(CDockWidgetTab* Tab);
+  void clearDockWidgetFocus(CDockWidget* dockWidget);
+  void setDockWidgetTabPressed(bool Value);
 
 public slots:
-	void setDockWidgetFocused(ads::CDockWidget* focusedNow);
-    
-}; // class DockFocusController
+  void setDockWidgetFocused(CDockWidget* focusedNow);    
 };
- // namespace ads
+
+};

--- a/sip/DockManager.sip
+++ b/sip/DockManager.sip
@@ -195,14 +195,7 @@ public:
   CDockWidget* createDockWidget(const QString& title, QWidget* parent /TransferThis/ = nullptr) /Factory/;
   CDockComponentsFactory* componentsFactory() const;
 %MethodCode
-    QSharedPointer<ads::CDockComponentsFactory> *grab;
-
-    Py_BEGIN_ALLOW_THREADS
-    // This will leak but there seems to be no way to detach the object.
-    grab = new QSharedPointer<ads::CDockComponentsFactory>(sipCpp->componentsFactory());
-    Py_END_ALLOW_THREADS
-
-    sipRes = grab->data();
+    sipres = sipCpp->componentsFactory().data();
 %End
   void setComponentsFactory(CDockComponentsFactory* Factory /Transfer/);
   // void setComponentsFactory(QSharedPointer<CDockComponentsFactory>); // not necessary

--- a/sip/DockManager.sip
+++ b/sip/DockManager.sip
@@ -195,7 +195,7 @@ public:
   CDockWidget* createDockWidget(const QString& title, QWidget* parent /TransferThis/ = nullptr) /Factory/;
   CDockComponentsFactory* componentsFactory() const;
 %MethodCode
-    sipres = sipCpp->componentsFactory().data();
+    sipRes = sipCpp->componentsFactory().data();
 %End
   void setComponentsFactory(CDockComponentsFactory* Factory /Transfer/);
   // void setComponentsFactory(QSharedPointer<CDockComponentsFactory>); // not necessary

--- a/sip/DockManager.sip
+++ b/sip/DockManager.sip
@@ -1,277 +1,286 @@
 %Import QtWidgets/QtWidgetsmod.sip
 
-%MappedType QMap<QString, ads::CDockWidget*>
-        /TypeHint="Dict[QString, CDockWidget*]", TypeHintValue="{}"/
+%MappedType QMap<QString, ads::CDockWidget*> /TypeHint="Dict[QString, CDockWidget*]", TypeHintValue="{}"/
 {
 %TypeHeaderCode
 #include <qmap.h>
 %End
 
 %ConvertFromTypeCode
-    PyObject *d = PyDict_New();
+  PyObject *d = PyDict_New();
 
-    if (!d)
-        return 0;
-    
-    QMap<QString, ads::CDockWidget*>::const_iterator it = sipCpp->constBegin();
-    QMap<QString, ads::CDockWidget*>::const_iterator end = sipCpp->constEnd();
+  if (!d)
+    return 0;
+  
+  QMap<QString, ads::CDockWidget*>::const_iterator it = sipCpp->constBegin();
+  QMap<QString, ads::CDockWidget*>::const_iterator end = sipCpp->constEnd();
 
-    while (it != end)
+  while (it != end)
+  {
+    QString *k = new QString(it.key());
+    PyObject *kobj = sipConvertFromType(k, sipType_QString, sipTransferObj);
+
+    if (!kobj)
     {
-        QString *k = new QString(it.key());
-        PyObject *kobj = sipConvertFromType(k, sipType_QString,
-                sipTransferObj);
+      delete k;
+      Py_DECREF(d);
 
-        if (!kobj)
-        {
-            delete k;
-            Py_DECREF(d);
-
-            return 0;
-        }
-
-        PyObject *vobj = sipConvertFromType(it.value(), sipType_ads_CDockWidget,
-                sipTransferObj);
-
-        if (!vobj)
-        {
-            Py_DECREF(kobj);
-            Py_DECREF(d);
-
-            return 0;
-        }
-
-        int rc = PyDict_SetItem(d, kobj, vobj);
-
-        Py_DECREF(vobj);
-        Py_DECREF(kobj);
-
-        if (rc < 0)
-        {
-            Py_DECREF(d);
-
-            return 0;
-        }
-
-        ++it;
+      return 0;
     }
-    
-    return d;
+
+    PyObject *vobj = sipConvertFromType(it.value(), sipType_ads_CDockWidget, sipTransferObj);
+
+    if (!vobj)
+    {
+      Py_DECREF(kobj);
+      Py_DECREF(d);
+
+      return 0;
+    }
+
+    int rc = PyDict_SetItem(d, kobj, vobj);
+
+    Py_DECREF(vobj);
+    Py_DECREF(kobj);
+
+    if (rc < 0)
+    {
+      Py_DECREF(d);
+
+      return 0;
+    }
+
+    ++it;
+  }
+  
+  return d;
 %End
 
 %ConvertToTypeCode
-    if (!sipIsErr)
-            return PyDict_Check(sipPy);
+  if (!sipIsErr)
+    return PyDict_Check(sipPy);
 
-    QMap<QString, ads::CDockWidget*> *qm = new QMap<QString, ads::CDockWidget*>;
-    
-    Py_ssize_t pos = 0;
-    PyObject *kobj, *vobj;
-    while (PyDict_Next(sipPy, &pos, &kobj, &vobj))
+  QMap<QString, ads::CDockWidget*> *qm = new QMap<QString, ads::CDockWidget*>;
+  
+  Py_ssize_t pos = 0;
+  PyObject *kobj, *vobj;
+  while (PyDict_Next(sipPy, &pos, &kobj, &vobj))
+  {
+    int kstate;
+    QString *k = reinterpret_cast<QString *>(sipForceConvertToType(kobj, sipType_QString, sipTransferObj, SIP_NOT_NONE, &kstate, sipIsErr));
+
+    if (*sipIsErr)
     {
-        int kstate;
-        QString *k = reinterpret_cast<QString *>(
-                sipForceConvertToType(kobj, sipType_QString, sipTransferObj,
-                        SIP_NOT_NONE, &kstate, sipIsErr));
-
-        if (*sipIsErr)
-        {
-            PyErr_Format(PyExc_TypeError,
-                    "a dict key has type '%s' but '_TYPE1_' is expected",
-                    sipPyTypeName(Py_TYPE(kobj)));
-
-            delete qm;
-
-            return 0;
-        }
-
-        int vstate;
-        ads::CDockWidget *v = reinterpret_cast<ads::CDockWidget *>(
-                sipForceConvertToType(vobj, sipType_ads_CDockWidget, sipTransferObj,
-                        SIP_NOT_NONE, &vstate, sipIsErr));
-
-        if (*sipIsErr)
-        {
-            PyErr_Format(PyExc_TypeError,
-                    "a dict value has type '%s' but '_TYPE2_' is expected",
-                    sipPyTypeName(Py_TYPE(vobj)));
-
-            sipReleaseType(k, sipType_QString, kstate);
-            delete qm;
-
-            return 0;
-        }
-
-        qm->insert(*k, v);
-
-        sipReleaseType(v, sipType_ads_CDockWidget, vstate);
-        sipReleaseType(k, sipType_QString, kstate);
+        PyErr_Format(PyExc_TypeError, "a dict key has type '%s' but '_TYPE1_' is expected", sipPyTypeName(Py_TYPE(kobj)));
+        delete qm;
+        return 0;
     }
- 
-    *sipCppPtr = qm;
- 
-    return sipGetState(sipTransferObj);
+
+    int vstate;
+    ads::CDockWidget *v = reinterpret_cast<ads::CDockWidget *>(sipForceConvertToType(vobj, sipType_ads_CDockWidget, sipTransferObj, SIP_NOT_NONE, &vstate, sipIsErr));
+
+    if (*sipIsErr)
+    {
+        PyErr_Format(PyExc_TypeError, "a dict value has type '%s' but '_TYPE2_' is expected", sipPyTypeName(Py_TYPE(vobj)));
+        sipReleaseType(k, sipType_QString, kstate);
+        delete qm;
+
+        return 0;
+    }
+
+    qm->insert(*k, v);
+
+    sipReleaseType(v, sipType_ads_CDockWidget, vstate);
+    sipReleaseType(k, sipType_QString, kstate);
+  }
+
+  *sipCppPtr = qm;
+
+  return sipGetState(sipTransferObj);
 %End
 };
 
 namespace ads
 {
 
-class CDockManager : ads::CDockContainerWidget
+class CDockManager : CDockContainerWidget
 {
-    
-    %TypeHeaderCode
-    #include <DockManager.h>
-    %End
+
+%TypeHeaderCode
+#include <DockManager.h>
+%End
 
 protected:
-	void registerFloatingWidget(ads::CFloatingDockContainer* FloatingWidget /Transfer/);
-	void removeFloatingWidget(ads::CFloatingDockContainer* FloatingWidget) /TransferBack/;
-	void registerDockContainer(ads::CDockContainerWidget* DockContainer /Transfer/);
-	void removeDockContainer(ads::CDockContainerWidget* DockContainer /TransferBack/);
-	ads::CDockOverlay* containerOverlay() const;
-	ads::CDockOverlay* dockAreaOverlay() const;
-    void notifyWidgetOrAreaRelocation(QWidget* RelocatedWidget);
-    void notifyFloatingWidgetDrop(ads::CFloatingDockContainer* FloatingWidget);
+  void registerFloatingWidget(CFloatingDockContainer* FloatingWidget /Transfer/);
+  void removeFloatingWidget(CFloatingDockContainer* FloatingWidget) /TransferBack/;
+  void registerDockContainer(CDockContainerWidget* DockContainer /Transfer/);
+  void removeDockContainer(CDockContainerWidget* DockContainer /TransferBack/);
+  CDockOverlay* containerOverlay() const;
+  CDockOverlay* dockAreaOverlay() const;
+  void notifyWidgetOrAreaRelocation(QWidget* RelocatedWidget);
+  void notifyFloatingWidgetDrop(CFloatingDockContainer* FloatingWidget);
 
-    virtual void showEvent(QShowEvent *event);
+  virtual void showEvent(QShowEvent *event);
 
 public:
-	enum eViewMenuInsertionOrder
+  enum eViewMenuInsertionOrder
+  {
+    MenuSortedByInsertion,
+    MenuAlphabeticallySorted
+  };
+
+  enum eConfigFlag
+  {
+    ActiveTabHasCloseButton,
+    DockAreaHasCloseButton,
+    DockAreaCloseButtonClosesTab,
+    OpaqueSplitterResize,
+    XmlAutoFormattingEnabled,
+    XmlCompressionEnabled,
+    TabCloseButtonIsToolButton,
+    AllTabsHaveCloseButton,
+    RetainTabSizeWhenCloseButtonHidden,
+    DragPreviewIsDynamic,
+    DragPreviewShowsContentPixmap,
+    DragPreviewHasWindowFrame,
+    AlwaysShowTabs,
+    DockAreaHasUndockButton,
+    DockAreaHasTabsMenuButton,
+    DockAreaHideDisabledButtons,
+    DockAreaDynamicTabsMenuButtonVisibility,
+    FloatingContainerHasWidgetTitle,
+    FloatingContainerHasWidgetIcon,
+    HideSingleCentralWidgetTitleBar,
+    FocusHighlighting,
+    EqualSplitOnInsertion,
+    FloatingContainerForceNativeTitleBar,
+    FloatingContainerForceQWidgetTitleBar,
+    MiddleMouseButtonClosesTab,
+    DisableTabTextEliding,
+    ShowTabTextOnlyForActiveTab,
+    DoubleClickUndocksWidget,
+    DefaultDockAreaButtons,
+    DefaultBaseConfig,
+    DefaultOpaqueConfig,
+    DefaultNonOpaqueConfig,
+    NonOpaqueWithWindowFrame,
+  };
+  typedef QFlags<ads::CDockManager::eConfigFlag> ConfigFlags;
+
+  enum eAutoHideFlag
+  {
+    AutoHideFeatureEnabled,
+    DockAreaHasAutoHideButton,
+    AutoHideButtonTogglesArea,
+    AutoHideButtonCheckable,
+    AutoHideSideBarsIconOnly,
+    AutoHideShowOnMouseOver,
+    AutoHideCloseButtonCollapsesDock,
+    AutoHideHasCloseButton,
+    AutoHideHasMinimizeButton,
+    AutoHideOpenOnDragHover,
+    AutoHideCloseOnOutsideMouseClick,
+    DefaultAutoHideConfig,
+  };
+  typedef QFlags<ads::CDockManager::eAutoHideFlag> AutoHideFlags;
+
+  enum eConfigParam
 	{
-		MenuSortedByInsertion,
-		MenuAlphabeticallySorted
+    AutoHideOpenOnDragHoverDelay_ms,
+    ConfigParamCount,
 	};
 
-	enum eConfigFlag
-	{
-		ActiveTabHasCloseButton,
-		DockAreaHasCloseButton,
-		DockAreaCloseButtonClosesTab,
-		OpaqueSplitterResize,
-		XmlAutoFormattingEnabled,
-		XmlCompressionEnabled,
-		TabCloseButtonIsToolButton,
-		AllTabsHaveCloseButton,
-		RetainTabSizeWhenCloseButtonHidden,
-		DragPreviewIsDynamic,
-		DragPreviewShowsContentPixmap,
-		DragPreviewHasWindowFrame,
-		AlwaysShowTabs,
-		DockAreaHasUndockButton,
-		DockAreaHasTabsMenuButton,
-		DockAreaHideDisabledButtons,
-		DockAreaDynamicTabsMenuButtonVisibility,
-		FloatingContainerHasWidgetTitle,
-		FloatingContainerHasWidgetIcon,
-		HideSingleCentralWidgetTitleBar,
-        FocusHighlighting,
-        EqualSplitOnInsertion,
-        FloatingContainerForceNativeTitleBar,
-        FloatingContainerForceQWidgetTitleBar,
-        MiddleMouseButtonClosesTab,
-        DisableTabTextEliding,
-        ShowTabTextOnlyForActiveTab,
-        DefaultDockAreaButtons,
-		DefaultBaseConfig,
-        DefaultOpaqueConfig,
-		DefaultNonOpaqueConfig,
-		NonOpaqueWithWindowFrame,
-	};
-    typedef QFlags<ads::CDockManager::eConfigFlag> ConfigFlags;
-	enum eAutoHideFlag
-	{
-		AutoHideFeatureEnabled,
-		DockAreaHasAutoHideButton,
-		AutoHideButtonTogglesArea,
-		AutoHideButtonCheckable,
-		AutoHideSideBarsIconOnly,
-		AutoHideShowOnMouseOver,
-        AutoHideCloseButtonCollapsesDock,
-        AutoHideHasCloseButton,
-        AutoHideHasMinimizeButton,
-		DefaultAutoHideConfig,
-	};
-    typedef QFlags<ads::CDockManager::eAutoHideFlag> AutoHideFlags;
+  CDockManager(QWidget* parent /TransferThis/ = nullptr);
+  virtual ~CDockManager();
+  CDockWidget* createDockWidget(const QString& title, QWidget* parent /TransferThis/ = nullptr) /Factory/;
+  CDockComponentsFactory* componentsFactory() const;
+%MethodCode
+    QSharedPointer<ads::CDockComponentsFactory> *grab;
 
-	CDockManager(QWidget* parent /TransferThis/ = 0);
-	virtual ~CDockManager();
-	static ads::CDockManager::ConfigFlags configFlags();
-	static void setConfigFlags(const ads::CDockManager::ConfigFlags Flags);
-	static void setConfigFlag(ads::CDockManager::eConfigFlag Flag, bool On = true);
-	static bool testConfigFlag(eConfigFlag Flag);
-	static ads::CDockManager::AutoHideFlags autoHideConfigFlags();
-	static void setAutoHideConfigFlags(const ads::CDockManager::AutoHideFlags Flags);
-	static void setAutoHideConfigFlag(ads::CDockManager::eAutoHideFlag Flag, bool On = true);
-	static bool testAutoHideConfigFlag(eAutoHideFlag Flag);
-    static ads::CIconProvider& iconProvider();
-	ads::CDockAreaWidget* addDockWidget(ads::DockWidgetArea area, ads::CDockWidget* Dockwidget /Transfer/,
-        ads::CDockAreaWidget* DockAreaWidget /Transfer/ = 0,
-		int Index = -1);
-	ads::CDockAreaWidget* addDockWidgetToContainer(ads::DockWidgetArea area, ads::CDockWidget* Dockwidget /Transfer/,
-	ads::CDockContainerWidget* DockContainerWidget /Transfer/ = 0);
-    ads::CAutoHideDockContainer* addAutoHideDockWidget(ads::SideBarLocation Location, ads::CDockWidget* Dockwidget /Transfer/);
-	ads::CAutoHideDockContainer* addAutoHideDockWidgetToContainer(SideBarLocation Location,
-		ads::CDockWidget* Dockwidget /Transfer/, ads::CDockContainerWidget* DockContainerWidget);
-	ads::CDockAreaWidget* addDockWidgetTab(ads::DockWidgetArea area,
-		ads::CDockWidget* Dockwidget /Transfer/);
-	ads::CDockAreaWidget* addDockWidgetTabToArea(ads::CDockWidget* Dockwidget /Transfer/,
-        ads::CDockAreaWidget* DockAreaWidget /Transfer/,
-		int Index = -1);
-    ads::CFloatingDockContainer* addDockWidgetFloating(ads::CDockWidget* DockWidget /Transfer/);
-	ads::CDockWidget* findDockWidget(const QString& ObjectName) const;
-	void removeDockWidget(ads::CDockWidget* Dockwidget) /TransferBack/;
-	QMap<QString, ads::CDockWidget*> dockWidgetsMap() const;
-	const QList<ads::CDockContainerWidget*> dockContainers() const;
-	const QList<ads::CFloatingDockContainer*> floatingWidgets() const;
-	unsigned int zOrderIndex() const;
-	QByteArray saveState(int version = 0) const;
-	bool restoreState(const QByteArray &state, int version = 0);
-	void addPerspective(const QString& UniquePrespectiveName);
-	void removePerspective(const QString& Name);
-	void removePerspectives(const QStringList& Names);
-	QStringList perspectiveNames() const;
-	void savePerspectives(QSettings& Settings) const;
-	void loadPerspectives(QSettings& Settings);
-    CDockWidget* centralWidget() const;
-    CDockAreaWidget* setCentralWidget(CDockWidget* widget /Transfer/);
-	QAction* addToggleViewActionToMenu(QAction* ToggleViewAction /Transfer/,
-		const QString& Group = QString(), const QIcon& GroupIcon = QIcon());
-	QMenu* viewMenu() const;
-	void setViewMenuInsertionOrder(ads::CDockManager::eViewMenuInsertionOrder Order);
-	bool isRestoringState() const;
-    bool isLeavingMinimizedState() const;
-	static int startDragDistance();
-    ads::CDockWidget* focusedDockWidget() const;
-    QList<int> splitterSizes(ads::CDockAreaWidget *ContainedArea) const;
-    void setSplitterSizes(ads::CDockAreaWidget *ContainedArea, const QList<int>& sizes);
-    static void setFloatingContainersTitle(const QString& Title);
-	static QString floatingContainersTitle();
-    void setDockWidgetToolBarStyle(Qt::ToolButtonStyle Style, ads::CDockWidget::eState State);
-    Qt::ToolButtonStyle dockWidgetToolBarStyle(ads::CDockWidget::eState State) const;
-    void setDockWidgetToolBarIconSize(const QSize& IconSize, ads::CDockWidget::eState State);
-    QSize dockWidgetToolBarIconSize(ads::CDockWidget::eState State) const;
-    ads::CDockWidget::DockWidgetFeatures globallyLockedDockWidgetFeatures() const;
-    void lockDockWidgetFeaturesGlobally(ads::CDockWidget::DockWidgetFeatures Features = ads::CDockWidget::GloballyLockableFeatures);
+    Py_BEGIN_ALLOW_THREADS
+    // This will leak but there seems to be no way to detach the object.
+    grab = new QSharedPointer<ads::CDockComponentsFactory>(sipCpp->componentsFactory());
+    Py_END_ALLOW_THREADS
+
+    sipRes = grab->data();
+%End
+  void setComponentsFactory(CDockComponentsFactory* Factory /Transfer/);
+  // void setComponentsFactory(QSharedPointer<CDockComponentsFactory>); // not necessary
+  static CDockManager::ConfigFlags configFlags();
+  static void setConfigFlags(const CDockManager::ConfigFlags Flags);
+  static void setConfigFlag(CDockManager::eConfigFlag Flag, bool On = true);
+  static bool testConfigFlag(eConfigFlag Flag);
+  static CDockManager::AutoHideFlags autoHideConfigFlags();
+  static void setAutoHideConfigFlags(const CDockManager::AutoHideFlags Flags);
+  static void setAutoHideConfigFlag(CDockManager::eAutoHideFlag Flag, bool On = true);
+  static bool testAutoHideConfigFlag(eAutoHideFlag Flag);
+  static void setConfigParam(eConfigParam Param, QVariant Value);
+  static QVariant configParam(eConfigParam Param, QVariant Default);
+  static CIconProvider& iconProvider();
+  CDockAreaWidget* addDockWidget(DockWidgetArea area, CDockWidget* Dockwidget /Transfer/, CDockAreaWidget* DockAreaWidget /Transfer/ = nullptr, int Index = -1);
+  CDockAreaWidget* addDockWidgetToContainer(DockWidgetArea area, CDockWidget* Dockwidget /Transfer/, CDockContainerWidget* DockContainerWidget /Transfer/ = nullptr);
+  CAutoHideDockContainer* addAutoHideDockWidget(SideBarLocation Location, CDockWidget* Dockwidget /Transfer/);
+  CAutoHideDockContainer* addAutoHideDockWidgetToContainer(SideBarLocation Location,
+  CDockWidget* Dockwidget /Transfer/, CDockContainerWidget* DockContainerWidget);
+  CDockAreaWidget* addDockWidgetTab(DockWidgetArea area,
+  CDockWidget* Dockwidget /Transfer/);
+  CDockAreaWidget* addDockWidgetTabToArea(CDockWidget* Dockwidget /Transfer/, CDockAreaWidget* DockAreaWidget /Transfer/, int Index = -1);
+  CFloatingDockContainer* addDockWidgetFloating(CDockWidget* DockWidget /Transfer/);
+  CDockWidget* findDockWidget(const QString& ObjectName) const;
+  void removeDockWidget(CDockWidget* Dockwidget) /TransferBack/;
+  QMap<QString, ads::CDockWidget*> dockWidgetsMap() const;
+  const QList<ads::CDockContainerWidget*> dockContainers() const;
+  const QList<ads::CFloatingDockContainer*> floatingWidgets() const;
+  unsigned int zOrderIndex() const;
+  QByteArray saveState(int version = 0) const;
+  bool restoreState(const QByteArray &state, int version = 0);
+  void addPerspective(const QString& UniquePrespectiveName);
+  void removePerspective(const QString& Name);
+  void removePerspectives(const QStringList& Names);
+  QStringList perspectiveNames() const;
+  void savePerspectives(QSettings& Settings) const;
+  void loadPerspectives(QSettings& Settings);
+  CDockWidget* centralWidget() const;
+  CDockAreaWidget* setCentralWidget(CDockWidget* widget /Transfer/);
+  QAction* addToggleViewActionToMenu(QAction* ToggleViewAction /Transfer/,
+  const QString& Group = QString(), const QIcon& GroupIcon = QIcon());
+  QMenu* viewMenu() const;
+  void setViewMenuInsertionOrder(CDockManager::eViewMenuInsertionOrder Order);
+  bool isRestoringState() const;
+  bool isLeavingMinimizedState() const;
+  static int startDragDistance();
+  CDockWidget* focusedDockWidget() const;
+  QList<int> splitterSizes(CDockAreaWidget *ContainedArea) const;
+  void setSplitterSizes(CDockAreaWidget *ContainedArea, const QList<int>& sizes);
+  static void setFloatingContainersTitle(const QString& Title);
+  static QString floatingContainersTitle();
+  void setDockWidgetToolBarStyle(Qt::ToolButtonStyle Style, CDockWidget::eState State);
+  Qt::ToolButtonStyle dockWidgetToolBarStyle(CDockWidget::eState State) const;
+  void setDockWidgetToolBarIconSize(const QSize& IconSize, CDockWidget::eState State);
+  QSize dockWidgetToolBarIconSize(CDockWidget::eState State) const;
+  CDockWidget::DockWidgetFeatures globallyLockedDockWidgetFeatures() const;
+  void lockDockWidgetFeaturesGlobally(CDockWidget::DockWidgetFeatures Features = ads::CDockWidget::GloballyLockableFeatures);
 
 public slots:
-    void endLeavingMinimizedState();
-	void openPerspective(const QString& PerspectiveName);
-    void setDockWidgetFocused(ads::CDockWidget* DockWidget);
+  void endLeavingMinimizedState();
+  void openPerspective(const QString& PerspectiveName);
+  void setDockWidgetFocused(CDockWidget* DockWidget);
+  void hideManagerAndFloatingWidgets();
 
 signals:
-	void perspectiveListChanged();
-	void perspectivesRemoved();
-	void restoringState();
-    void stateRestored();
-    void openingPerspective(const QString& PerspectiveName);
-    void perspectiveOpened(const QString& PerspectiveName);
-	void floatingWidgetCreated(ads::CFloatingDockContainer*);
-    void dockAreaCreated(ads::CDockAreaWidget*);
-    void dockWidgetAdded(ads::CDockWidget* DockWidget);
-    void dockWidgetAboutToBeRemoved(ads::CDockWidget*);
-    void dockWidgetRemoved(ads::CDockWidget*);
-    void focusedDockWidgetChanged(ads::CDockWidget*, ads::CDockWidget*);
+  void perspectiveListChanged();
+  void perspectiveListLoaded();
+  void perspectivesRemoved();
+  void restoringState();
+  void stateRestored();
+  void openingPerspective(const QString& PerspectiveName);
+  void perspectiveOpened(const QString& PerspectiveName);
+  void floatingWidgetCreated(CFloatingDockContainer*);
+  void dockAreaCreated(CDockAreaWidget*);
+  void dockWidgetAdded(CDockWidget* DockWidget);
+  void dockWidgetAboutToBeRemoved(CDockWidget*);
+  void dockWidgetRemoved(CDockWidget*);
+  void focusedDockWidgetChanged(CDockWidget*, CDockWidget*);
 };
 
 };

--- a/sip/DockWidget.sip
+++ b/sip/DockWidget.sip
@@ -5,150 +5,150 @@ namespace ads
 
 class CDockWidget : QFrame
 {
-    %TypeHeaderCode
-    #include <DockWidget.h>
-    %End
-    
+%TypeHeaderCode
+#include <DockWidget.h>
+%End
+
 protected:
-    void setDockManager(ads::CDockManager* DockManager /Transfer/ );
-    void setDockArea(ads::CDockAreaWidget* DockArea /Transfer/ );
-    void setToggleViewActionChecked(bool Checked);
-    void saveState(QXmlStreamWriter& Stream) const;
-    void flagAsUnassigned();
-    static void emitTopLevelEventForWidget(ads::CDockWidget* TopLevelDockWidget, bool Floating);
-    void emitTopLevelChanged(bool Floating);
-    void setClosedState(bool Closed);
-    void toggleViewInternal(bool Open);
-    bool closeDockWidgetInternal(bool ForceClose = false);
-    
-public:
-	enum DockWidgetFeature
-	{
-		DockWidgetClosable,
-		DockWidgetMovable,
-		DockWidgetFloatable,
-		DockWidgetDeleteOnClose,
-        CustomCloseHandling,
-        DockWidgetFocusable,
-        DockWidgetForceCloseWithArea,
-        NoTab,
-        DeleteContentOnClose,
-        DockWidgetPinnable,
-        DefaultDockWidgetFeatures,
-        AllDockWidgetFeatures,
-        DockWidgetAlwaysCloseAndDelete,
-        GloballyLockableFeatures,
-		NoDockWidgetFeatures
-	};
-    typedef QFlags<ads::CDockWidget::DockWidgetFeature> DockWidgetFeatures;
-
-	enum eState
-	{
-		StateHidden,
-		StateDocked,
-		StateFloating
-	};
-    
-    enum eToolBarStyleSource
-    {
-    	ToolBarStyleFromDockManager,
-    	ToolBarStyleFromDockWidget
-    };
-
-	enum eInsertMode
-	{
-		AutoScrollArea,
-		ForceScrollArea,
-		ForceNoScrollArea
-	};
-	
-    enum eMinimumSizeHintMode
-    {
-    	MinimumSizeHintFromDockWidget,
-    	MinimumSizeHintFromContent,
-        MinimumSizeHintFromDockWidgetMinimumSize,
-    	MinimumSizeHintFromContentMinimumSize,
-    };
-
-	enum eToggleViewActionMode
-	{
-		ActionModeToggle,
-		ActionModeShow
-	};
-
-
-	CDockWidget(const QString &title, QWidget* parent /TransferThis/ = Q_NULLPTR);
-	virtual ~CDockWidget();
-	virtual QSize minimumSizeHint() const;
-	void setWidget(QWidget* widget /Transfer/, ads::CDockWidget::eInsertMode InsertMode = AutoScrollArea);
-	QWidget* takeWidget() /TransferBack/;
-	QWidget* widget() const;
-	ads::CDockWidgetTab* tabWidget() const;
-	void setFeatures(ads::CDockWidget::DockWidgetFeatures features);
-	void setFeature(ads::CDockWidget::DockWidgetFeature flag, bool on);
-	ads::CDockWidget::DockWidgetFeatures features() const;
-    void notifyFeaturesChanged();
-	ads::CDockManager* dockManager() const;
-	ads::CDockContainerWidget* dockContainer() const;
-    ads::CFloatingDockContainer* floatingDockContainer() const;
-	ads::CDockAreaWidget* dockAreaWidget() const;
-    ads::CAutoHideTab* sideTabWidget() const;
-    void setSideTabWidget(ads::CAutoHideTab* SideTab /Transfer/) const;
-    bool isAutoHide() const;
-    ads::CAutoHideDockContainer* autoHideDockContainer() const;
-    ads::SideBarLocation autoHideLocation() const;
-	bool isFloating() const;
-	bool isInFloatingContainer() const;
-	bool isClosed() const;
-	QAction* toggleViewAction() const;
-    void setToggleViewAction(QAction* action);
-	void setToggleViewActionMode(ads::CDockWidget::eToggleViewActionMode Mode);
-	void setMinimumSizeHintMode(ads::CDockWidget::eMinimumSizeHintMode Mode);
-    ads::CDockWidget::eMinimumSizeHintMode minimumSizeHintMode() const;
-    bool isCentralWidget() const;
-	void setIcon(const QIcon& Icon);
-	QIcon icon() const;
-	QToolBar* toolBar() const;
-	QToolBar* createDefaultToolBar();
-	void setToolBar(QToolBar* ToolBar /Transfer/ );
-    void setToolBarStyleSource(ads::CDockWidget::eToolBarStyleSource Source);
-    ads::CDockWidget::eToolBarStyleSource toolBarStyleSource() const;
-	void setToolBarStyle(Qt::ToolButtonStyle Style, ads::CDockWidget::eState State);
-	Qt::ToolButtonStyle toolBarStyle(ads::CDockWidget::eState State) const;
-	void setToolBarIconSize(const QSize& IconSize, ads::CDockWidget::eState State);
-	QSize toolBarIconSize(eState State) const;
-    void setTitleBarActions(QList<QAction*> actions);
-    virtual QList<QAction*> titleBarActions() const;
-
-	void setTabToolTip(const QString &text);
-    bool isFullScreen() const;
-    bool isTabbed() const;
-    bool isCurrentTab() const;
+  void setDockManager(CDockManager* DockManager /Transfer/ );
+  void setDockArea(CDockAreaWidget* DockArea /Transfer/ );
+  void setToggleViewActionChecked(bool Checked);
+  void saveState(QXmlStreamWriter& Stream) const;
+  void flagAsUnassigned();
+  static void emitTopLevelEventForWidget(CDockWidget* TopLevelDockWidget, bool Floating);
+  void emitTopLevelChanged(bool Floating);
+  void setClosedState(bool Closed);
+  void toggleViewInternal(bool Open);
+  bool closeDockWidgetInternal(bool ForceClose = false);
 
 public:
-	virtual bool event(QEvent *e);
+  enum DockWidgetFeature
+  {
+    DockWidgetClosable,
+    DockWidgetMovable,
+    DockWidgetFloatable,
+    DockWidgetDeleteOnClose,
+    CustomCloseHandling,
+    DockWidgetFocusable,
+    DockWidgetForceCloseWithArea,
+    NoTab,
+    DeleteContentOnClose,
+    DockWidgetPinnable,
+    DefaultDockWidgetFeatures,
+    AllDockWidgetFeatures,
+    DockWidgetAlwaysCloseAndDelete,
+    GloballyLockableFeatures,
+    NoDockWidgetFeatures
+  };
+  typedef QFlags<ads::CDockWidget::DockWidgetFeature> DockWidgetFeatures;
+
+  enum eState
+  {
+    StateHidden,
+    StateDocked,
+    StateFloating
+  };
+
+  enum eToolBarStyleSource
+  {
+    ToolBarStyleFromDockManager,
+    ToolBarStyleFromDockWidget
+  };
+
+  enum eInsertMode
+  {
+    AutoScrollArea,
+    ForceScrollArea,
+    ForceNoScrollArea
+  };
+  
+  enum eMinimumSizeHintMode
+  {
+    MinimumSizeHintFromDockWidget,
+    MinimumSizeHintFromContent,
+    MinimumSizeHintFromDockWidgetMinimumSize,
+    MinimumSizeHintFromContentMinimumSize,
+  };
+
+  enum eToggleViewActionMode
+  {
+    ActionModeToggle,
+    ActionModeShow
+  };
+
+
+  explicit CDockWidget(const QString &title, QWidget* parent /TransferThis/ = nullptr);
+  CDockWidget(CDockManager *manager /Transfer/, const QString &title, QWidget* parent /TransferThis/ = nullptr);
+  virtual ~CDockWidget();
+  virtual QSize minimumSizeHint() const;
+  void setWidget(QWidget* widget /Transfer/, CDockWidget::eInsertMode InsertMode = AutoScrollArea);
+  QWidget* takeWidget() /TransferBack/;
+  QWidget* widget() const;
+  CDockWidgetTab* tabWidget() const;
+  void setFeatures(CDockWidget::DockWidgetFeatures features);
+  void setFeature(CDockWidget::DockWidgetFeature flag, bool on);
+  CDockWidget::DockWidgetFeatures features() const;
+  CDockManager* dockManager() const;
+  CDockContainerWidget* dockContainer() const;
+  CFloatingDockContainer* floatingDockContainer() const;
+  CDockAreaWidget* dockAreaWidget() const;
+  CAutoHideTab* sideTabWidget() const;
+  void setSideTabWidget(CAutoHideTab* SideTab /Transfer/) const;
+  bool isAutoHide() const;
+  CAutoHideDockContainer* autoHideDockContainer() const;
+  SideBarLocation autoHideLocation() const;
+  bool isFloating() const;
+  bool isInFloatingContainer() const;
+  bool isClosed() const;
+  QAction* toggleViewAction() const;
+  void setToggleViewAction(QAction* action /Transfer/);
+  void setToggleViewActionMode(CDockWidget::eToggleViewActionMode Mode);
+  void setMinimumSizeHintMode(CDockWidget::eMinimumSizeHintMode Mode);
+  CDockWidget::eMinimumSizeHintMode minimumSizeHintMode() const;
+  bool isCentralWidget() const;
+  void setIcon(const QIcon& Icon);
+  QIcon icon() const;
+  QToolBar* toolBar() const;
+  QToolBar* createDefaultToolBar();
+  void setToolBar(QToolBar* ToolBar /Transfer/);
+  void setToolBarStyleSource(eToolBarStyleSource Source);
+  eToolBarStyleSource toolBarStyleSource() const;
+  void setToolBarStyle(Qt::ToolButtonStyle Style, CDockWidget::eState State);
+  Qt::ToolButtonStyle toolBarStyle(CDockWidget::eState State) const;
+  void setToolBarIconSize(const QSize& IconSize, CDockWidget::eState State);
+  QSize toolBarIconSize(eState State) const;
+  void setTitleBarActions(QList<QAction*> actions);
+  virtual QList<QAction*> titleBarActions() const;
+
+  void setTabToolTip(const QString &text);
+  bool isFullScreen() const;
+  bool isTabbed() const;
+  bool isCurrentTab() const;
+
+public:
+  virtual bool event(QEvent *e);
 
 public slots:
-	void toggleView(bool Open = true);
-	void setAsCurrentTab();
-	void raise();
-    void setFloating();
-    void deleteDockWidget();
-    void closeDockWidget();
-    void requestCloseDockWidget();
-    void showFullScreen();
-    void showNormal();
-    void setAutoHide(bool Enable, ads::SideBarLocation Location = ads::SideBarNone, int TabIndex = -1);
-	void toggleAutoHide(ads::SideBarLocation Location = ads::SideBarNone);
+  void toggleView(bool Open = true);
+  void setAsCurrentTab();
+  void raise();
+  void setFloating();
+  void deleteDockWidget();
+  void closeDockWidget();
+  void requestCloseDockWidget();
+  void showFullScreen();
+  void showNormal();
+  void setAutoHide(bool Enable, SideBarLocation Location = ads::SideBarNone, int TabIndex = -1);
+  void toggleAutoHide(SideBarLocation Location = ads::SideBarNone);
 
 signals:
-	void viewToggled(bool Open);
-	void closed();
-	void titleChanged(const QString& Title);
-	void topLevelChanged(bool topLevel);
-    void closeRequested();
-	void visibilityChanged(bool visible);
-    void featuresChanged(ads::CDockWidget::DockWidgetFeatures features);
+  void viewToggled(bool Open);
+  void closed();
+  void titleChanged(const QString& Title);
+  void topLevelChanged(bool topLevel);
+  void closeRequested();
+  void visibilityChanged(bool visible);
+  void featuresChanged(CDockWidget::DockWidgetFeatures features);
 };
 
 };

--- a/sip/DockWidgetTab.sip
+++ b/sip/DockWidgetTab.sip
@@ -5,47 +5,49 @@ namespace ads
 
 class CDockWidgetTab : QFrame
 {
-    %TypeHeaderCode
-    #include <DockWidgetTab.h>
-    %End
-    
+%TypeHeaderCode
+#include <DockWidgetTab.h>
+%End
+
 protected:
-	virtual void mousePressEvent(QMouseEvent* ev);
-	virtual void mouseReleaseEvent(QMouseEvent* ev);
-	virtual void mouseMoveEvent(QMouseEvent* ev);
-	virtual void contextMenuEvent(QContextMenuEvent* ev);
-	virtual void mouseDoubleClickEvent(QMouseEvent *event);
+  virtual void mousePressEvent(QMouseEvent* ev);
+  virtual void mouseReleaseEvent(QMouseEvent* ev);
+  virtual void mouseMoveEvent(QMouseEvent* ev);
+  virtual void contextMenuEvent(QContextMenuEvent* ev);
+  virtual void mouseDoubleClickEvent(QMouseEvent *event);
 
 public:
-	CDockWidgetTab(ads::CDockWidget* DockWidget /TransferThis/, QWidget* parent /TransferThis/ = 0);
-	virtual ~CDockWidgetTab();
-	bool isActiveTab() const;
-	void setActiveTab(bool active);
-	void setDockAreaWidget(ads::CDockAreaWidget* DockArea /Transfer/);
-	ads::CDockAreaWidget* dockAreaWidget() const;
-	ads::CDockWidget* dockWidget() const;
-	void setIcon(const QIcon& Icon);
-	const QIcon& icon() const;
-	QString text() const;
-	void setText(const QString& title);
-	bool isTitleElided() const;
-	bool isClosable() const;
-	virtual bool event(QEvent *e);
-	void setElideMode(Qt::TextElideMode mode);
-    void updateStyle();
-    QSize iconSize() const;
-    void setIconSize(const QSize& Size);
+  CDockWidgetTab(CDockWidget* DockWidget /TransferThis/, QWidget* parent /TransferThis/ = nullptr);
+  virtual ~CDockWidgetTab();
+  bool isActiveTab() const;
+  void setActiveTab(bool active);
+  void setDockAreaWidget(CDockAreaWidget* DockArea /Transfer/);
+  CDockAreaWidget* dockAreaWidget() const;
+  CDockWidget* dockWidget() const;
+  void setIcon(const QIcon& Icon);
+  const QIcon& icon() const;
+  QString text() const;
+  void setText(const QString& title);
+  bool isTitleElided() const;
+  bool isClosable() const;
+  virtual bool event(QEvent *e);
+  void setElideMode(Qt::TextElideMode mode);
+  void updateStyle();
+  QSize iconSize() const;
+  void setIconSize(const QSize& Size);
+  eDragState dragState() const;
+  virtual QMenu *buildContextMenu(QMenu* menu /Transfer/ = nullptr);
 
 public slots:
-	virtual void setVisible(bool visible);
+  virtual void setVisible(bool visible);
 
 signals:
-	void activeTabChanged();
-	void clicked();
-	void closeRequested();
-	void closeOtherTabsRequested();
-	void moved(const QPoint& GlobalPos);
-	void elidedChanged(bool elided);
-}; // class DockWidgetTab
+  void activeTabChanged();
+  void clicked();
+  void closeRequested();
+  void closeOtherTabsRequested();
+  void moved(const QPoint& GlobalPos);
+  void elidedChanged(bool elided);
 };
- // namespace ads
+
+};

--- a/sip/DockingStateReader.sip
+++ b/sip/DockingStateReader.sip
@@ -3,15 +3,13 @@ namespace ads
 
 class CDockingStateReader : QXmlStreamReader
 {
-
-    %TypeHeaderCode
-    #include <DockingStateReader.h>
-    %End
-
+%TypeHeaderCode
+#include <DockingStateReader.h>
+%End
 
 public:
-	void setFileVersion(int FileVersion);
-	int fileVersion() const;
+  void setFileVersion(int FileVersion);
+  int fileVersion() const;
 };
 
 };

--- a/sip/ElidingLabel.sip
+++ b/sip/ElidingLabel.sip
@@ -5,33 +5,33 @@ namespace ads
 
 class CElidingLabel : QLabel
 {
-    %TypeHeaderCode
-    #include <ElidingLabel.h>
-    %End
+%TypeHeaderCode
+#include <ElidingLabel.h>
+%End
     
 protected:
-	virtual void mouseReleaseEvent(QMouseEvent* event);
-    virtual void resizeEvent( QResizeEvent *event );
-    virtual void mouseDoubleClickEvent( QMouseEvent *ev );
+  virtual void mouseReleaseEvent(QMouseEvent* event);
+  virtual void resizeEvent( QResizeEvent *event);
+  virtual void mouseDoubleClickEvent( QMouseEvent *ev);
     
 public:
-	CElidingLabel(QWidget* parent /TransferThis/ = Q_NULLPTR, Qt::WindowFlags f = Qt::WindowFlags ());
-	CElidingLabel(const QString& text, QWidget* parent /TransferThis/ = Q_NULLPTR, Qt::WindowFlags f = Qt::WindowFlags ());
-	virtual ~CElidingLabel();
-	Qt::TextElideMode elideMode() const;
-	void setElideMode(Qt::TextElideMode mode);
-	bool isElided() const;
+  CElidingLabel(QWidget* parent /TransferThis/ = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+  CElidingLabel(const QString& text, QWidget* parent /TransferThis/ = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+  virtual ~CElidingLabel();
+  Qt::TextElideMode elideMode() const;
+  void setElideMode(Qt::TextElideMode mode);
+  bool isElided() const;
 
 public:
-	virtual QSize minimumSizeHint() const;
-	virtual QSize sizeHint() const;
-	void setText(const QString &text);
-	QString text() const;
+  virtual QSize minimumSizeHint() const;
+  virtual QSize sizeHint() const;
+  void setText(const QString &text);
+  QString text() const;
 
 signals:
-	void clicked();
-	void doubleClicked();
-	void elidedChanged(bool elided);
+  void clicked();
+  void doubleClicked();
+  void elidedChanged(bool elided);
 };
 
 };

--- a/sip/FloatingDockContainer.sip
+++ b/sip/FloatingDockContainer.sip
@@ -4,10 +4,10 @@
 %Import QtWidgets/QtWidgetsmod.sip
 
 %If (Linux)
-    typedef QDockWidget tFloatingWidgetBase;
+	typedef QDockWidget tFloatingWidgetBase;
 %End
 %If (!Linux)
-    typedef QWidget tFloatingWidgetBase;
+	typedef QWidget tFloatingWidgetBase;
 %End
 
 namespace ads
@@ -15,82 +15,74 @@ namespace ads
 
 class IFloatingWidget
 {
-    %TypeHeaderCode
-    #include <FloatingDockContainer.h>
-    %End
+%TypeHeaderCode
+#include <FloatingDockContainer.h>
+%End
 
 public:
-	virtual void startFloating(const QPoint& DragStartMousePos, const QSize& Size,
-        ads::eDragState DragState, QWidget* MouseEventHandler) = 0;
-
+	virtual void startFloating(const QPoint& DragStartMousePos, const QSize& Size, eDragState DragState, QWidget* MouseEventHandler) = 0;
 	virtual void moveFloating() = 0;
 	virtual void finishDragging() = 0;
 	virtual ~IFloatingWidget();
 };
 
-
-class CFloatingDockContainer : tFloatingWidgetBase, ads::IFloatingWidget
+class CFloatingDockContainer : tFloatingWidgetBase, IFloatingWidget
 {
-    
-    %TypeHeaderCode
-    #include <FloatingDockContainer.h>
-    %End
-    
+%TypeHeaderCode
+#include <FloatingDockContainer.h>
+%End
+
 protected:
-	virtual void startFloating(const QPoint& DragStartMousePos, const QSize& Size,
-        ads::eDragState DragState, QWidget* MouseEventHandler);
-    void startDragging(const QPoint& DragStartMousePos, const QSize& Size,
-        QWidget* MouseEventHandler);
+	virtual void startFloating(const QPoint& DragStartMousePos, const QSize& Size, eDragState DragState, QWidget* MouseEventHandler);
 	virtual void finishDragging();
-    void deleteContent();
+	void deleteContent();
 	void initFloatingGeometry(const QPoint& DragStartMousePos, const QSize& Size);
 	void moveFloating();
-	bool restoreState(ads::CDockingStateReader& Stream, bool Testing);
+	bool restoreState(CDockingStateReader& Stream, bool Testing);
 	void updateWindowTitle();
-
 
 protected:
 	virtual void changeEvent(QEvent *event);
 	virtual void closeEvent(QCloseEvent *event);
 	virtual void hideEvent(QHideEvent *event);
 	virtual void showEvent(QShowEvent *event);
-    
-    %If (macOS)
-    virtual bool event(QEvent *e);
-	virtual void moveEvent(QMoveEvent *event);
-    %End
-    
-    %If (Linux)
-    virtual void moveEvent(QMoveEvent *event);
-	virtual void resizeEvent(QResizeEvent *event);
-    virtual bool event(QEvent *e);
-    %End
-    
-	%If (Windows)
-	virtual bool nativeEvent(const QByteArray &eventType, void *message, qintptr *result);
-	%End
 
+%If (macOS)
+	virtual bool event(QEvent *e);
+	virtual void moveEvent(QMoveEvent *event);
+%End
+	
+%If (Linux)
+	virtual void moveEvent(QMoveEvent *event);
+	virtual void resizeEvent(QResizeEvent *event);
+	virtual bool event(QEvent *e);
+%End
+	
+%If (Windows)
+	virtual bool nativeEvent(const QByteArray &eventType, void *message, qintptr *result);
+%End
 
 public:
-	CFloatingDockContainer(ads::CDockManager* DockManager /TransferThis/);
-	CFloatingDockContainer(ads::CDockAreaWidget* DockArea /TransferThis/);
-	CFloatingDockContainer(ads::CDockWidget* DockWidget /TransferThis/);
+	CFloatingDockContainer(CDockManager* DockManager /TransferThis/);
+	CFloatingDockContainer(CDockAreaWidget* DockArea /TransferThis/);
+	CFloatingDockContainer(CDockWidget* DockWidget /TransferThis/);
 	virtual ~CFloatingDockContainer();
-	ads::CDockContainerWidget* dockContainer() const;
-    bool isClosable() const;
-    bool hasTopLevelDockWidget() const;
-    ads::CDockWidget* topLevelDockWidget() const;
-    QList<ads::CDockWidget*> dockWidgets() const;
-    void finishDropOperation();
-    
-    %If (Linux)
-    void onMaximizeRequest();
+	CDockContainerWidget* dockContainer() const;
+	void startDragging(const QPoint& DragStartMousePos, const QSize& Size, QWidget* MouseEventHandler);
+	bool isClosable() const;
+	bool hasTopLevelDockWidget() const;
+	CDockWidget* topLevelDockWidget() const;
+	QList<ads::CDockWidget*> dockWidgets() const;
+	void finishDropOperation();
+	
+%If (Linux)
+	void onMaximizeRequest();
 	void showNormal(bool fixGeometry);
 	void showMaximized();
 	bool isMaximized() const;
 	void show();
 	bool hasNativeTitleBar();
-    %End
+%End
 };
 
 };

--- a/sip/FloatingDragPreview.sip
+++ b/sip/FloatingDragPreview.sip
@@ -5,33 +5,30 @@ namespace ads
 
 class CFloatingDragPreview : QWidget, ads::IFloatingWidget
 {
-
-    %TypeHeaderCode
-    #include <FloatingDragPreview.h>
-    %End
+%TypeHeaderCode
+#include <FloatingDragPreview.h>
+%End
 
 protected:
-	virtual void paintEvent(QPaintEvent *e);
-	CFloatingDragPreview(QWidget* Content /TransferThis/, QWidget* parent /TransferThis/);
+  virtual void paintEvent(QPaintEvent *e);
+  CFloatingDragPreview(QWidget* Content /TransferThis/, QWidget* parent /TransferThis/);
 
 public:
-    CFloatingDragPreview(ads::CDockWidget* Content /TransferThis/ );
-    CFloatingDragPreview(ads::CDockAreaWidget* Content /TransferThis/ );
+  CFloatingDragPreview(ads::CDockWidget* Content /TransferThis/);
+  CFloatingDragPreview(ads::CDockAreaWidget* Content /TransferThis/ );
 
-    virtual ~CFloatingDragPreview();
+  virtual ~CFloatingDragPreview();
 
-    virtual bool eventFilter(QObject* watched, QEvent* event);
+  virtual bool eventFilter(QObject* watched, QEvent* event);
 
 public: // implements IFloatingWidget
-    virtual void startFloating(const QPoint& DragStartMousePos, const QSize& Size,
-        ads::eDragState DragState, QWidget* MouseEventHandler);
-    virtual void moveFloating();
-    virtual void finishDragging();
-    void cleanupAutoHideContainerWidget(ads::DockWidgetArea ContainerDropArea);
+  virtual void startFloating(const QPoint& DragStartMousePos, const QSize& Size, eDragState DragState, QWidget* MouseEventHandler);
+  virtual void moveFloating();
+  virtual void finishDragging();
+  void cleanupAutoHideContainerWidget(ads::DockWidgetArea ContainerDropArea);
 
 signals:
-    void draggingCanceled();
-
+  void draggingCanceled();
 };
 
 };

--- a/sip/IconProvider.sip
+++ b/sip/IconProvider.sip
@@ -5,20 +5,15 @@ namespace ads
 
 class CIconProvider
 {
-
-    %TypeHeaderCode
-    #include <IconProvider.h>
-    %End
-
+%TypeHeaderCode
+#include <IconProvider.h>
+%End
 
 public:
-    CIconProvider();
-
-  	virtual ~CIconProvider();
-
-    QIcon customIcon(eIcon IconId);
-
-    void registerCustomIcon(eIcon IconId, const QIcon& icon /TransferThis/ );
+  CIconProvider();
+  virtual ~CIconProvider();
+  QIcon customIcon(eIcon IconId);
+  void registerCustomIcon(eIcon IconId, const QIcon& icon /TransferThis/ );
 };
 
 };

--- a/sip/PushButton.sip
+++ b/sip/PushButton.sip
@@ -3,24 +3,22 @@
 namespace ads
 {
 
-
 class CPushButton : QPushButton
 {
-    %TypeHeaderCode
-    #include <PushButton.h>
-    %End
+%TypeHeaderCode
+#include <PushButton.h>
+%End
     
 public:
-    enum Orientation {
-        Horizontal,
-        VerticalTopToBottom,
-        VerticalBottomToTop
-    };
-    virtual QSize sizeHint() const;
-    
-    ads::CPushButton::Orientation buttonOrientation() const;
-    void setButtonOrientation(ads::CPushButton::Orientation orientation);
-
+  enum Orientation {
+    Horizontal,
+    VerticalTopToBottom,
+    VerticalBottomToTop
+  };
+  virtual QSize sizeHint() const;
+  
+  CPushButton::Orientation buttonOrientation() const;
+  void setButtonOrientation(CPushButton::Orientation orientation);
 };
 
 };

--- a/sip/ResizeHandle.sip
+++ b/sip/ResizeHandle.sip
@@ -5,28 +5,27 @@ namespace ads
 
 class CResizeHandle : QFrame
 {
-
-    %TypeHeaderCode
-    #include <ResizeHandle.h>
-    %End
+%TypeHeaderCode
+#include <ResizeHandle.h>
+%End
 
 protected:
-	void mouseMoveEvent(QMouseEvent *);
-    void mousePressEvent(QMouseEvent *);
-    void mouseReleaseEvent(QMouseEvent *);
+  void mouseMoveEvent(QMouseEvent *);
+  void mousePressEvent(QMouseEvent *);
+  void mouseReleaseEvent(QMouseEvent *);
 
 public:
-	CResizeHandle(Qt::Edge HandlePosition, QWidget* parent /TransferThis/);
-	virtual ~CResizeHandle();
-	void setHandlePosition(Qt::Edge HandlePosition);
-	Qt::Edge handlePostion() const;
-	Qt::Orientation orientation() const;
-	QSize sizeHint() const;
-	bool isResizing() const;
-	void setMinResizeSize(int MinSize);
-	void setMaxResizeSize(int MaxSize);
-	void setOpaqueResize(bool opaque = true);
-	bool opaqueResize() const;
+  CResizeHandle(Qt::Edge HandlePosition, QWidget* parent /TransferThis/);
+  virtual ~CResizeHandle();
+  void setHandlePosition(Qt::Edge HandlePosition);
+  Qt::Edge handlePostion() const;
+  Qt::Orientation orientation() const;
+  QSize sizeHint() const;
+  bool isResizing() const;
+  void setMinResizeSize(int MinSize);
+  void setMaxResizeSize(int MaxSize);
+  void setOpaqueResize(bool opaque = true);
+  bool opaqueResize() const;
 };
 
 };

--- a/sip/ads_globals.sip
+++ b/sip/ads_globals.sip
@@ -36,9 +36,9 @@ PyObject *qtads_FindParent(PyObject* type, const QWidget *w)
 
 namespace ads
 {
-    %TypeHeaderCode
-    #include <ads_globals.h>
-    %End
+%TypeHeaderCode
+#include <ads_globals.h>
+%End
 
     enum DockWidgetArea
     {
@@ -58,7 +58,6 @@ namespace ads
         AllDockAreas
     };
     typedef QFlags<ads::DockWidgetArea> DockWidgetAreas;
-
 
     enum eTabIndex
     {
@@ -90,6 +89,7 @@ namespace ads
         DockAreaMenuIcon,
         DockAreaUndockIcon,
         DockAreaCloseIcon,
+        DockAreaMinimizeIcon,
         IconCount,
     };
 
@@ -155,5 +155,4 @@ namespace ads
        void repolishStyle(QWidget* w, ads::internal::eRepolishChildOptions Options = ads::internal::RepolishIgnoreChildren); 
        QRect globalGeometry(QWidget* w);
     };
-
 };

--- a/sip/linux/FloatingWidgetTitleBar.sip
+++ b/sip/linux/FloatingWidgetTitleBar.sip
@@ -2,9 +2,9 @@
 
 namespace ads
 {
-    %TypeHeaderCode
-    #include <linux/FloatingWidgetTitleBar.h>
-    %End
+%TypeHeaderCode
+#include <linux/FloatingWidgetTitleBar.h>
+%End
     
 class CFloatingWidgetTitleBar : QWidget
 {


### PR DESCRIPTION
closes #9 

@char101,  Thanks for these.  This updates just uses your files directly (with the exception, for the moment, of the `ads.sip`, until i/we decide on whether to add QtAds inside the PyQt6 namespace).

I've left all your whitespace changes in as well.  It's all the same to me and perhaps will make your life easier if you'd like to contribute in the future.  I also added you as an author to this commit, hope that's ok with you