### PR TITLE
fix windows dll directories 

### DIFF
--- a/scripts/repair_wheel.py
+++ b/scripts/repair_wheel.py
@@ -37,7 +37,7 @@ def main() -> None:
 RPATH_RE_MAC = re.compile(r"^\s*path (.+) \(offset \d+\)$", re.MULTILINE)
 
 
-def fix_rpath_macos(so: Path, new_rpath: str = "@loader_path/PyQt6/Qt6/lib") -> None:
+def fix_rpath_macos(so: Path, new_rpath: str = "@loader_path/../PyQt6/Qt6/lib") -> None:
     # delete all current rpaths
     current_rpath = run(["otool", "-l", str(so)], capture_output=True, text=True)
     for rpath in RPATH_RE_MAC.findall(current_rpath.stdout):
@@ -48,7 +48,7 @@ def fix_rpath_macos(so: Path, new_rpath: str = "@loader_path/PyQt6/Qt6/lib") -> 
     print(f"Updated RPATH for {so} to {new_rpath}")
 
 
-def fix_rpath_linux(so: Path, new_rpath: str = "$ORIGIN/PyQt6/Qt6/lib") -> None:
+def fix_rpath_linux(so: Path, new_rpath: str = "$ORIGIN/../PyQt6/Qt6/lib") -> None:
     # delete all current rpaths
     current_rpath = run(
         ["patchelf", "--print-rpath", str(so)], capture_output=True, text=True

--- a/sip/PyQt6Ads.sip
+++ b/sip/PyQt6Ads.sip
@@ -1,4 +1,4 @@
-%Module(name=PyQt6Ads, call_super_init=True, keyword_arguments="Optional", use_limited_api=True)
+%Module(name=PyQt6Ads._ads, call_super_init=True, keyword_arguments="Optional", use_limited_api=True)
 %HideNamespace(name=ads)
 
 %Import QtCore/QtCoremod.sip

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2,6 +2,7 @@ import runpy
 from pathlib import Path
 from unittest.mock import patch
 
+import PyQt6Ads  # noqa  # import here to ensure that it works regardless of order
 import pytest
 from PyQt6.QtWidgets import QApplication
 


### PR DESCRIPTION
this distributes as package instead of single module, and import from hidden `_ads` module so we can import PyQt6 first.  (note, i'm just importing PyQt6 rather than manually finding the Qt/bin directories and calling `os.add_dll_directory`

fixes #8 